### PR TITLE
Add Splunk App for Corda

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Pull requests are welcome!
 
 ## Contents
 
+- [Contents](#contents)
 - [Documentation](#documentation)
 - [Programming](#programming)
 - [Tools](#tools)
@@ -25,6 +26,7 @@ Pull requests are welcome!
 - [Community](#community)
 - [Misc](#misc)
 - [Official](#official)
+- [Contribute](#contribute)
 
 
 ## Documentation
@@ -59,6 +61,7 @@ Pull requests are welcome!
 - [VS Code Corda extension](https://github.com/corda/vscode-corda) - VS Code tools for developing CorDapps on the Corda platform.
 - [Web3j integration for Corda](http://corda.web3j.io/) - A lightweight client library for working with CorDapps.
 - [XTS Fountain](https://cordite.foundation/) - Mint XTS tokens and send them to a token account on a Corda node.
+- [Splunk App for Corda](https://github.com/splunkdlt/splunk-app-for-corda) - Splunk official integration app for Corda monitoring. 
 
 ## Tutorials
 


### PR DESCRIPTION
 Adding this new official tool [just announced](https://medium.com/splunk-dlt/introducing-splunk-app-for-corda-enhanced-visibility-into-your-r3-corda-blockchain-network-68d5229358c5). 